### PR TITLE
fix: set first match max points

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,7 @@ $("#start-match-day").click(function() {
     }
 
     maxPoints = parseInt($("#max-points").val());
+    currentMatchMaxPoints = maxPoints;
     playersPerTeam = $("#players-per-team").val();
     
     if (playersPerTeam * 2 > players.length) {


### PR DESCRIPTION
A primeira partida de cada pelada não estava finalizando.

- Debugando o `currentMatchMaxPoints` estava `undefined` na primeira partida.
- Aparentemente ele só seria setado no `startNewMatch` ou restaurando algum jogo em andamento no `$(document).ready`
- Portanto ele não estava sendo chamado no `$("#start-match-day").click` ao iniciar uma nova pelada.
- Só setei o `currentMatchMaxPoints` para o valor de `maxPoints` ao iniciar a nova pelada.